### PR TITLE
fix: outdent indented numbered-list item (1 tutorial)

### DIFF
--- a/tutorials/joule-studio-codejam-5-skill-create/joule-studio-codejam-5-skill-create.md
+++ b/tutorials/joule-studio-codejam-5-skill-create/joule-studio-codejam-5-skill-create.md
@@ -339,7 +339,7 @@ You will create two **Send Message** steps, one for each of the condition branch
 
     Click **Save**.
 
-  4. Click **Save** (upper right).
+4. Click **Save** (upper right).
 
 
 ### Test the skill


### PR DESCRIPTION
## Summary

Outdents 1 numbered-list item in `joule-studio-codejam-5-skill-create` so it sits flush with sibling `3.` instead of being interpreted by CommonMark as a nested `<ol start="4">`. Detected by [`tutorials-ims/scripts/lint-tutorial-markdown.ts`](https://github.com/sap-tutorials/tutorials-ims/blob/main/scripts/lint-tutorial-markdown.ts) and tracked in [tutorials-ims#193](https://github.com/sap-tutorials/tutorials-ims/issues/193).

## Changes

| Tutorial | Line | Fix |
|---|---|---|
| `joule-studio-codejam-5-skill-create` | L342 | Outdent `4. Click **Save** (upper right).` from 2-space indent to flush-left to match sibling `3.` |

CommonMark continuation content within prior items retains its existing indent.

## Verification

Run [`lint-tutorial-markdown`](https://github.com/sap-tutorials/tutorials-ims/blob/main/scripts/lint-tutorial-markdown.ts) against a fresh `.tutorial-cache/` after merge — this tutorial should drop off the report.

## Related

- Platform-side fix: [tutorials-ims#190](https://github.com/sap-tutorials/tutorials-ims/pull/190) (merged)
- Author-side lint: [tutorials-ims#191](https://github.com/sap-tutorials/tutorials-ims/pull/191) (merged)
- Original report: [tutorials-ims#168](https://github.com/sap-tutorials/tutorials-ims/issues/168) (closed)
- Tracking: [tutorials-ims#193](https://github.com/sap-tutorials/tutorials-ims/issues/193)
